### PR TITLE
Update MultiArrayLayout.h

### DIFF
--- a/stm32/ros_usbnode/src/ros/ros_lib/std_msgs/MultiArrayLayout.h
+++ b/stm32/ros_usbnode/src/ros/ros_lib/std_msgs/MultiArrayLayout.h
@@ -26,6 +26,10 @@ namespace std_msgs
     {
     }
 
+    virtual ~MultiArrayLayout() {
+      delete[] dim;
+    }
+
     virtual int serialize(unsigned char *outbuffer) const override
     {
       int offset = 0;
@@ -34,8 +38,8 @@ namespace std_msgs
       *(outbuffer + offset + 2) = (this->dim_length >> (8 * 2)) & 0xFF;
       *(outbuffer + offset + 3) = (this->dim_length >> (8 * 3)) & 0xFF;
       offset += sizeof(this->dim_length);
-      for( uint32_t i = 0; i < dim_length; i++){
-      offset += this->dim[i].serialize(outbuffer + offset);
+      for(uint32_t i = 0; i < dim_length; i++) {
+        offset += this->dim[i].serialize(outbuffer + offset);
       }
       *(outbuffer + offset + 0) = (this->data_offset >> (8 * 0)) & 0xFF;
       *(outbuffer + offset + 1) = (this->data_offset >> (8 * 1)) & 0xFF;
@@ -53,19 +57,24 @@ namespace std_msgs
       dim_lengthT |= ((uint32_t) (*(inbuffer + offset + 2))) << (8 * 2); 
       dim_lengthT |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3); 
       offset += sizeof(this->dim_length);
-      if(dim_lengthT > dim_length)
-        this->dim = (std_msgs::MultiArrayDimension*)realloc(this->dim, dim_lengthT * sizeof(std_msgs::MultiArrayDimension));
-      dim_length = dim_lengthT;
-      for( uint32_t i = 0; i < dim_length; i++){
-      offset += this->st_dim.deserialize(inbuffer + offset);
-        memcpy( &(this->dim[i]), &(this->st_dim), sizeof(std_msgs::MultiArrayDimension));
+
+      // Allouer de la mémoire si la taille a changé
+      if (dim_lengthT != dim_length) {
+        delete[] this->dim;  // Libère l'ancienne mémoire
+        this->dim = new std_msgs::MultiArrayDimension[dim_lengthT];  // Alloue de la nouvelle mémoire
       }
-      this->data_offset =  ((uint32_t) (*(inbuffer + offset)));
+
+      dim_length = dim_lengthT;
+      for(uint32_t i = 0; i < dim_length; i++) {
+        offset += this->dim[i].deserialize(inbuffer + offset); // Utiliser l'affectation directe
+      }
+
+      this->data_offset = ((uint32_t) (*(inbuffer + offset)));
       this->data_offset |= ((uint32_t) (*(inbuffer + offset + 1))) << (8 * 1);
       this->data_offset |= ((uint32_t) (*(inbuffer + offset + 2))) << (8 * 2);
       this->data_offset |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3);
       offset += sizeof(this->data_offset);
-     return offset;
+      return offset;
     }
 
     virtual const char * getType() override { return "std_msgs/MultiArrayLayout"; };


### PR DESCRIPTION
Explication des modifications

    Suppression de realloc : Nous avons supprimé l’appel à realloc et utilisé new pour allouer de la mémoire pour dim si la taille (dim_lengthT) a changé.
    Libération de la mémoire : Avant d’allouer un nouveau tableau, l’ancien est libéré avec delete[] pour éviter les fuites de mémoire.
    Assignation directe : Chaque élément de dim est désérialisé individuellement sans memcpy ni realloc, car MultiArrayDimension n’est pas triviale en copie.


!!!!! À modifier en même temp que tfmessage.h  !!!!!