### PR TITLE
Change default platform back to Yardforce500

### DIFF
--- a/stm32/ros_usbnode/platformio.ini
+++ b/stm32/ros_usbnode/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = Yardforce500B
+default_envs = Yardforce500
 
 [env]
 platform = ststm32


### PR DESCRIPTION
When merging in the 500b branch, the default got switched to 500b, but really it should probably remain the 500 classic.