### PR TITLE
/fix firmware build problem in setup

### DIFF
--- a/stm32/ros_usbnode/include/board.h.template
+++ b/stm32/ros_usbnode/include/board.h.template
@@ -52,6 +52,7 @@ extern "C"
 
 #define OPTION_ULTRASONIC 0
 #define OPTION_BUMPER 0
+#define BOARD_HAS_MASTER_USART 1
 #elif defined(BOARD_LUV1000RI)
 #define PANEL_TYPE {{.PanelType}}
 #define BLADEMOTOR_LENGTH_RECEIVED_MSG 14
@@ -65,7 +66,7 @@ extern "C"
 #define PWM_PER_MPS 300.0 // PWM value of 300 means 1 m/s bot speed so we divide by 4 to have correct robot speed but still progressive speed
 #define TICKS_PER_M {{.TickPerM}} // Motor Encoder ticks per meter
 #define WHEEL_BASE {{.WheelBase}}   // The distance between the center of the wheels in meters
-
+#define BOARD_HAS_MASTER_USART 0
 #else
 
 #error "No board selection"


### PR DESCRIPTION
The Setup function that allows flashing the firmware to the Yardforce board uses a board.h.template file, that is applied to board.h by the firmware.go file. The template file was lacking the definition of BOARD_HAS_MASTER_USART, leading to undefined reference to `MASTER_Transmit' in ros_usbnode main.c file.

The change consists in adding definitions to BOARD_HAS_MASTER_USART in the board.h.template file.