### PR TITLE
Option to disable emergency in area recording mode

### DIFF
--- a/stm32/ros_usbnode/include/board.h
+++ b/stm32/ros_usbnode/include/board.h
@@ -94,6 +94,7 @@ extern "C"
 #endif
 
 //#define I_DONT_NEED_MY_FINGERS              1      // disables EmergencyController() (no wheel lift, or tilt sensing and stopping the blade anymore)
+#define I_DONT_NEED_MY_FINGERS_WHEN_RECORDING 1      //   disables EmergencyController in area recording mode only
 
 /// nominal max charge current is 1.0 Amp
 #define MAX_CHARGE_CURRENT 1.0f

--- a/stm32/ros_usbnode/src/emergency.c
+++ b/stm32/ros_usbnode/src/emergency.c
@@ -52,17 +52,23 @@ uint8_t Emergency_State(void)
  * @brief Set Emergency State bits
  * @retval none
  */
-void  Emergency_SetState(uint8_t new_emergency_state)
+void Emergency_SetState(uint8_t new_emergency_state)
 {
-    switch (new_emergency_state)  {
+    switch (new_emergency_state)
+    {
         case EMERGENCY_CHECKING_DISABLE:
             emergency_checking_disabled = true;
             emergency_state = 0;
             break;
+
         case EMERGENCY_CHECKING_ENABLE:
             emergency_checking_disabled = false;
+            emergency_state = 0;
+            break;
+
         default:
             emergency_state = new_emergency_state;
+            break;
     }
 }
 

--- a/stm32/ros_usbnode/src/main.c
+++ b/stm32/ros_usbnode/src/main.c
@@ -45,6 +45,11 @@
 #include "cpp_main.h"
 #include "ringbuffer.h"
 
+#ifdef I_DONT_NEED_MY_FINGERS_WHEN_RECORDING
+#define EMERGENCY_CHECKING_DISABLE_LOCAL 2
+#define EMERGENCY_CHECKING_ENABLE_LOCAL 3
+#endif
+
 static void WATCHDOG_vInit(void);
 static void WATCHDOG_Refresh(void);
 void TIM4_Init(void);
@@ -293,10 +298,27 @@ int main(void)
     }
 
 #ifndef I_DONT_NEED_MY_FINGERS
-    if (NBT_handler(&main_emergency_nbt))
-    {
-      EmergencyController();
+if (NBT_handler(&main_emergency_nbt)) {
+
+#ifdef I_DONT_NEED_MY_FINGERS_WHEN_RECORDING
+    static uint8_t emergency_was_disabled_for_recording = 0;
+
+    if (main_eOpenmowerStatus == OPENMOWER_STATUS_RECORD) {
+        Emergency_SetState(EMERGENCY_CHECKING_DISABLE_LOCAL);
+        emergency_was_disabled_for_recording = 1;
+    } else {
+        if (emergency_was_disabled_for_recording) {
+            Emergency_SetState(EMERGENCY_CHECKING_ENABLE_LOCAL);
+            emergency_was_disabled_for_recording = 0;
+        }
+
+        EmergencyController();
     }
+#else
+    EmergencyController();
+#endif
+
+}
 #endif
   }
   /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
normal emergency handling in idle/mowing
emergency disabled only while OPENMOWER_STATUS_RECORD
emergency cleared when entering recording
no permanent emergency state after leaving recording

@Nekraus could you please take a look if the implementation is okay. I have tested this on my 500 and my other 500B and it works okay. 