### PR TITLE
Improve ST-Link flashing and battery 7s calibration

### DIFF
--- a/stm32/ros_usbnode/include/board.h
+++ b/stm32/ros_usbnode/include/board.h
@@ -47,7 +47,7 @@ extern "C"
 
 #define MAX_MPS 0.5		  // Allow maximum speed of 1.0 m/s
 #define PWM_PER_MPS 300.0 // PWM value of 300 means 1 m/s bot speed so we divide by 4 to have correct robot speed but still progressive speed
-#define TICKS_PER_M 300.0 // Motor Encoder ticks per meter
+#define TICKS_PER_M 1964.0 // Motor Encoder ticks per meter
 #define WHEEL_BASE  0.325		// The distance between the center of the wheels in meters
 
 #define OPTION_ULTRASONIC 0
@@ -94,11 +94,11 @@ extern "C"
 //#define I_DONT_NEED_MY_FINGERS              1      // disables EmergencyController() (no wheel lift, or tilt sensing and stopping the blade anymore)
 
 /// nominal max charge current is 1.0 Amp
-#define MAX_CHARGE_CURRENT 1.0f
+#define MAX_CHARGE_CURRENT 1.2f
 /// Max voltage allowed 29.4
 #define MAX_CHARGE_VOLTAGE 29.4f
 /// Default max battery voltage allowed
-#define BAT_CHARGE_CUTOFF_VOLTAGE  28.0f
+#define BAT_CHARGE_CUTOFF_VOLTAGE  29.2f
 /// We consider the battery is full when in CV mode the current below 0.1A
 #define CHARGE_END_LIMIT_CURRENT 0.08f
 // if voltage is greater than this assume we are docked
@@ -108,8 +108,8 @@ extern "C"
 
 // if current is greater than this assume the battery is charging
 #define MIN_CHARGE_CURRENT 0.1f
-#define LOW_BAT_THRESHOLD 25.2f /* near 20% SOC */
-#define LOW_CRI_THRESHOLD 23.5f /* near 0% SOC */
+#define LOW_BAT_THRESHOLD 23.0f /* near 20% SOC */
+#define LOW_CRI_THRESHOLD 22.5f /* near 0% SOC */
 
 // Emergency sensor timeouts
 #define ONE_WHEEL_LIFT_EMERGENCY_MILLIS 10000

--- a/stm32/ros_usbnode/platformio.ini
+++ b/stm32/ros_usbnode/platformio.ini
@@ -28,6 +28,7 @@ platform_packages =
 	platformio/tool-stm32duino@^1.0.1
 	platformio/tool-openocd@^2.1100.211028
 	platformio/tool-dfuutil@^1.11.0
+
 build_flags = -DBOARD_YARDFORCE500_VARIANT_ORIG=1 -Wl,--undefined,_printf_float  -O2 -Isrc/ros/ros_lib -Isrc/ros/ros_custom
 extra_scripts =
 	pre:patch_usb.py

--- a/stm32/ros_usbnode/platformio.ini
+++ b/stm32/ros_usbnode/platformio.ini
@@ -14,6 +14,8 @@ default_envs = Yardforce500
 [env]
 platform = ststm32
 framework = stm32cube
+upload_protocol = custom
+upload_command = st-flash --reset write $BUILD_DIR/firmware.bin 0x08000000
 build_src_filter =
 	+<*>
 	-<.git/>
@@ -26,9 +28,8 @@ board = genericSTM32F103VC
 platform_packages = 
     toolchain-gccarmnoneeabi@~1.90301.0
 	platformio/tool-stm32duino@^1.0.1
-	platformio/tool-openocd@^2.1100.211028
+	;platformio/tool-openocd@^2.1100.211028
 	platformio/tool-dfuutil@^1.11.0
-
 build_flags = -DBOARD_YARDFORCE500_VARIANT_ORIG=1 -Wl,--undefined,_printf_float  -O2 -Isrc/ros/ros_lib -Isrc/ros/ros_custom
 extra_scripts =
 	pre:patch_usb.py
@@ -42,7 +43,7 @@ board = genericSTM32F401VC
 platform_packages =
 	toolchain-gccarmnoneeabi@~1.90301.0
 	platformio/tool-stm32duino@^1.0.1
-	platformio/tool-openocd@^2.1100.211028
+	;platformio/tool-openocd@^2.1100.211028
 	platformio/tool-dfuutil@^1.11.0
 	platformio/framework-stm32cubef4@^1.26.2
 build_flags = -DBOARD_YARDFORCE500_VARIANT_B=1 -Wl,--undefined,_printf_float  -O2 -Isrc/ros/ros_lib -Isrc/ros/ros_custom -DHSE_VALUE=8000000u

--- a/stm32/ros_usbnode/tools/openocd/stlink-swd-f1.cfg
+++ b/stm32/ros_usbnode/tools/openocd/stlink-swd-f1.cfg
@@ -1,0 +1,8 @@
+adapter driver st-link
+transport select dapdirect_swd
+
+source [find target/stm32f1x.cfg]
+
+adapter speed 4000
+
+reset_config srst_only srst_nogate connect_assert_srst

--- a/stm32/ros_usbnode/tools/openocd/stlink-swd-f4.cfg
+++ b/stm32/ros_usbnode/tools/openocd/stlink-swd-f4.cfg
@@ -1,0 +1,8 @@
+adapter driver st-link
+transport select dapdirect_swd
+
+source [find target/stm32f4x.cfg]
+
+adapter speed 4000
+
+reset_config srst_only srst_nogate connect_assert_srst


### PR DESCRIPTION
## Summary

This PR includes two updates for the Yardforce500 firmware:

- Replace the OpenOCD-based ST-Link upload method with `st-flash`.
  - Improves compatibility with ST-Link V2/V3.
  - Avoids OpenOCD `hla_swd` transport issues.
  - Tested successfully with ST-Link V3.

- Update Yardforce500 calibration values:
  - `TICKS_PER_M`: `300.0` → `1964.0`
  - `MAX_CHARGE_CURRENT`: `1.0f` → `1.2f`
  - `BAT_CHARGE_CUTOFF_VOLTAGE`: `28.0f` → `29.2f`
  - `LOW_BAT_THRESHOLD`: `25.2f` → `23.0f`
  - `LOW_CRI_THRESHOLD`: `23.5f` → `22.5f`

## Test

- Build OK for `Yardforce500`
- Upload OK using ST-Link V3 + `st-flash`
- Flash write verified successfully