### PR TITLE
Fix OPTION_PERIMETER

### DIFF
--- a/stm32/ros_usbnode/include/perimeter.h
+++ b/stm32/ros_usbnode/include/perimeter.h
@@ -13,6 +13,8 @@
 #ifndef __PERIMETER_H
 #define __PERIMETER_H
 
+#include "board.h"
+
 #ifdef OPTION_PERIMETER
 
 /******************************************************************************


### PR DESCRIPTION
`adc.c` did not include `board.h`, so `OPTION_PERIMETER` would always be undefined and PERIMETER_vITHandle() would never be called.

Btw would you please consider enabling issues and/or discussions? Your fork has diverged significantly from cloudn1ne's repo, so I think it makes sense to have a separate issue tracker.