### PR TITLE
Fix OPTION_PERIMETER

### DIFF
--- a/stm32/ros_usbnode/include/perimeter.h
+++ b/stm32/ros_usbnode/include/perimeter.h
@@ -13,6 +13,8 @@
 #ifndef __PERIMETER_H
 #define __PERIMETER_H
 
+#include "board.h"
+
 #ifdef OPTION_PERIMETER
 
 /******************************************************************************


### PR DESCRIPTION
This pull requests is like https://github.com/cedbossneo/Mowgli/pull/38 but targetting the v2 branch.

`adc.c` did not include `board.h`, so `OPTION_PERIMETER` would always be undefined and `PERIMETER_vITHandle()` would never be called.