### PR TITLE
Report `chargerInputVoltage` in `charge_voltage_adc` to fix docking detection

### DIFF
--- a/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
+++ b/stm32/ros_usbnode/src/ros/ros_custom/cpp_main.cpp
@@ -622,7 +622,7 @@ extern "C" void broadcast_handler()
 		om_power_msg.battery_voltage_adc = battery_voltage;
 		om_power_msg.battery_voltage_chg = battery_voltage;
 		om_power_msg.battery_voltage_bms = battery_voltage;
-		om_power_msg.charge_voltage_adc = charge_voltage;
+		om_power_msg.charge_voltage_adc = chargerInputVoltage;
 		om_power_msg.charge_voltage_chg = charge_voltage;
 		om_power_msg.charge_current = current;
 		om_power_msg.charger_enabled = chargecontrol_is_charging;


### PR DESCRIPTION
Currently both `charge_voltage_adc` and `charge_voltage_chg` are `charge_voltage`. However, `charge_voltage` appears to be something coming from the charger DC/DC converter. It takes several seconds to rise after the mower makes contact with the dock. This causes the mower to keep pushing the dock for over a second during perimeter wire docking (I have not tried GPS docking). This only happens on the v2 branch, since main reports `chargerInputVoltage` instead.

This commit reports the raw `chargerInputVoltage` (I believe this is the voltage on the docking contacts) in `charge_voltage_adc` while keeping `charge_voltage` in `charge_voltage_chg`.

I am not sure whether this is the correct approach, but it does fix my docking problems on v2.